### PR TITLE
Versioning example for sealing a class

### DIFF
--- a/Versioning/examples/seal-class-protected-contructor.txt
+++ b/Versioning/examples/seal-class-protected-contructor.txt
@@ -1,0 +1,35 @@
+public class LibraryClass
+{
+    protected LibraryClass()
+    {
+        Console.WriteLine("LibraryClass constructor called");
+    }
+}
+----
+public sealed class LibraryClass
+{
+    protected LibraryClass()
+    {
+        Console.WriteLine("LibraryClass constructor called");
+    }
+}
+----
+public class DerivedClass : LibraryClass
+{
+}
+
+public class Program
+{
+    static void Main()
+    {
+        new DerivedClass();
+    }
+}
+----
+# Sealing a class with a public or protected constructor
+
+Adding the sealed modifier to a class with a public or protected constructor
+is a simple breaking change for both source and binary compatibility. Note
+that in the absence of any constructors, a default, public constructor will
+be available, so sealing a class without a constructor will also be a
+breaking change.


### PR DESCRIPTION
Produces the following page:

---
title: Sealing a class with a public or protected constructor
---
# Sealing a class with a public or protected constructor

Adding the sealed modifier to a class with a public or protected constructor
is a simple breaking change for both source and binary compatibility. Note
that in the absence of any constructors, a default, public constructor will
be available, so sealing a class without a constructor will also be a
breaking change.

----
Library code before:
```csharp
using System;

namespace Library
{
    public class LibraryClass
    {
        protected LibraryClass()
        {
            Console.WriteLine("LibraryClass constructor called");
        }
    }
}
```
----
Library code after:
```csharp
using System;

namespace Library
{
    public sealed class LibraryClass
    {
        protected LibraryClass()
        {
            Console.WriteLine("LibraryClass constructor called");
        }
    }
}
```
----
Client code:
```csharp
using System;
using Library;

namespace Client
{
    public class DerivedClass : LibraryClass
    {
    }

    public class Program
    {
        static void Main()
        {
            new DerivedClass();
        }
    }
}
```
----
Initial results:
```text
LibraryClass constructor called
```
----
Results of running Client.exe before recompiling:
```text

Unhandled Exception: System.TypeLoadException: Could not load type 'Client.DerivedClass' from assembly 'Client, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' because the parent type is sealed.
   at Client.Program.Main()
```
----
Results of running Client.exe after recompiling:
```text
Client.cs(6,18): error CS0509: 'DerivedClass': cannot derive from sealed type 'LibraryClass'
```
----
[Back to index](index.md)
