### PR TITLE
Versioning example: add interface member

### DIFF
--- a/Versioning/examples/add-interface-member.txt
+++ b/Versioning/examples/add-interface-member.txt
@@ -1,0 +1,31 @@
+public interface ILibraryInterface
+{
+    void Method1();
+}
+----
+public interface ILibraryInterface
+{
+    void Method1();
+    void Method2();
+}
+----
+public class ClientClass : ILibraryInterface
+{
+    public void Method1()
+    {
+        Console.WriteLine("Method1 called");
+    }
+}
+
+public class Program
+{
+    static void Main()
+    {
+        new ClientClass().Method1();
+    }
+}
+----
+# Adding an interface member
+
+Adding a member to an interface definition is a simple breaking change for
+both source and binary compatibility.


### PR DESCRIPTION
Produces the following page:

---
title: Adding an interface member
---
# Adding an interface member

Adding a member to an interface definition is a simple breaking change for
both source and binary compatibility.

----
Library code before:
```csharp
using System;

namespace Library
{
    public interface ILibraryInterface
    {
        void Method1();
    }
}
```
----
Library code after:
```csharp
using System;

namespace Library
{
    public interface ILibraryInterface
    {
        void Method1();
        void Method2();
    }
}
```
----
Client code:
```csharp
using System;
using Library;

namespace Client
{
    public class ClientClass : ILibraryInterface
    {
        public void Method1()
        {
            Console.WriteLine("Method1 called");
        }
    }

    public class Program
    {
        static void Main()
        {
            new ClientClass().Method1();
        }
    }
}
```
----
Initial results:
```text
Method1 called
```
----
Results of running Client.exe before recompiling:
```text

Unhandled Exception: System.TypeLoadException: Method 'Method2' in type 'Client.ClientClass' from assembly 'Client, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' does not have an implementation.
   at Client.Program.Main()
```
----
Results of running Client.exe after recompiling:
```text
Client.cs(6,32): error CS0535: 'ClientClass' does not implement interface member 'ILibraryInterface.Method2()'
```
----
[Back to index](index.md)
