### PR TITLE
Minor tidy-ups for the V-Drum Explorer

### DIFF
--- a/Drums/VDrumExplorer.Data/Fields/FixedContainer.cs
+++ b/Drums/VDrumExplorer.Data/Fields/FixedContainer.cs
@@ -97,5 +97,20 @@ namespace VDrumExplorer.Data.Fields
             }
             return new ValidationResult(count, errors.AsReadOnly());
         }
+
+        public IEnumerable<FixedContainer> DescendantsAndSelf()
+        {
+            var queue = new Queue<FixedContainer>();
+            queue.Enqueue(this);
+            while (queue.Count != 0)
+            {
+                var current = queue.Dequeue();
+                yield return current;
+                foreach (var container in current.Container.Fields.OfType<Container>())
+                {
+                    queue.Enqueue(current.ToChildContext(container));
+                }
+            }
+        }
     }
 }

--- a/Drums/VDrumExplorer.Data/Json/DynamicOverlayJson.cs
+++ b/Drums/VDrumExplorer.Data/Json/DynamicOverlayJson.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace VDrumExplorer.Data.Json
 {
     /// <summary>
-    /// The JSON representation of information about the dynamic overlay 
+    /// The JSON representation of information about a dynamic overlay.
     /// </summary>
     internal sealed class DynamicOverlayJson
     {
@@ -24,19 +24,15 @@ namespace VDrumExplorer.Data.Json
         public HexInt32? Size { get; set; }
 
         /// <summary>
-        /// The offset relative to the start of the parent container, at which
-        /// to find the value to switch between dynamic overlays. This may be an offset into a different
-        /// container.
+        /// The offset of the container holding the switch field, relative to the start of the parent container
+        /// of this field.
         /// </summary>
-        public HexInt32? SwitchOffset { get; set; }
+        public HexInt32? SwitchContainerOffset { get; set; }
 
         /// <summary>
-        /// Any transform to apply. Currently supported value "instrumentGroup", which expects
-        /// the target of the offset to be an instrument field. The instrument group is determined from that.
-        /// (An extra container is expected after all the preset instruments, for user samples, as they're
-        /// not in an instrument group.)
+        /// The name of the switch field within the switch container.
         /// </summary>
-        public string? SwitchTransform { get; set; }
+        public string? SwitchField { get; set; }
 
         /// <summary>
         /// The containers to switch between.

--- a/Drums/VDrumExplorer.Data/Json/FieldJson.cs
+++ b/Drums/VDrumExplorer.Data/Json/FieldJson.cs
@@ -267,14 +267,15 @@ namespace VDrumExplorer.Data.Json
                 // Offsets within each container are relative to the parent container of this field,
                 // not relative to this field itself.
                 var overlay = ValidateNotNull(DynamicOverlay, nameof(DynamicOverlay));
-                var switchOffset = ValidateNotNull(overlay.SwitchOffset, nameof(overlay.SwitchOffset)).Value;
+                var switchContainerOffset = ValidateNotNull(overlay.SwitchContainerOffset, nameof(overlay.SwitchContainerOffset)).Value;
+                var switchField = ValidateNotNull(overlay.SwitchField, nameof(overlay.SwitchField));
                 var containers = ValidateNotNull(overlay.Containers, nameof(overlay.Containers))
                     .Select((json, index) => json.ToContainer(schema, module, Invariant($"Overlay[{index}]"), 0, description, condition: null))
                     .ToList()
                     .AsReadOnly();
                 var size = ValidateNotNull(overlay.Size, nameof(overlay.Size));
                 var common = new FieldBase.Parameters(schema, name, offset, size.Value, description, condition: null);
-                return new DynamicOverlay(common, switchOffset, overlay.SwitchTransform, containers);
+                return new DynamicOverlay(common, switchContainerOffset, switchField, containers);
             }
 
             Container BuildContainer()

--- a/Drums/VDrumExplorer.Data/Json/VisualTreeConversionContext.cs
+++ b/Drums/VDrumExplorer.Data/Json/VisualTreeConversionContext.cs
@@ -50,24 +50,21 @@ namespace VDrumExplorer.Data.Json
             return new VisualTreeConversionContext(moduleJson, ContainerContext, lookupsByPath, newIndexes);
         }
 
-        internal FieldChain<Container?> GetContainer(string relativePath) =>
-            relativePath == "."
-            ? FieldChain<Container?>.EmptyChain(null)
-            : FieldChain<Container?>.Create(ContainerContext.Container, ReplaceIndexes(relativePath));
+        internal FixedContainer GetContext(string relativePath)
+        {
+            if (relativePath == ".")
+            {
+                return ContainerContext;
+            }
+            var chain = FieldChain<Container>.Create(ContainerContext.Container, ReplaceIndexes(relativePath));
+            return chain.GetFinalContext(ContainerContext).ToChildContext(chain.FinalField);
+        }
 
         internal FieldChain<MidiNoteField> GetMidiNoteField(string relativePath) =>
             FieldChain<MidiNoteField>.Create(ContainerContext.Container, ReplaceIndexes(relativePath));
 
-        internal VisualTreeConversionContext WithPath(string relativePath)
-        {
-            if (relativePath == ".")
-            {
-                return this;
-            }
-            var chain = FieldChain<Container>.Create(ContainerContext.Container, ReplaceIndexes(relativePath));
-            var newContainerContext = chain.GetFinalContext(ContainerContext).ToChildContext(chain.FinalField);
-            return new VisualTreeConversionContext(moduleJson, newContainerContext, lookupsByPath, indexes);
-        }
+        internal VisualTreeConversionContext WithContextFromPath(string relativePath) =>
+            new VisualTreeConversionContext(moduleJson, GetContext(relativePath), lookupsByPath, indexes);
 
         internal int? GetRepeat(string? repeat) => moduleJson.GetCount(repeat);
 

--- a/Drums/VDrumExplorer.Data/Json/VisualTreeDetailJson.cs
+++ b/Drums/VDrumExplorer.Data/Json/VisualTreeDetailJson.cs
@@ -31,8 +31,7 @@ namespace VDrumExplorer.Data.Json
                 ValidateNull(Format, nameof(Format), nameof(Repeat));
                 ValidateNull(FormatPaths, nameof(FormatPaths), nameof(Repeat));
 
-                var container = context.GetContainer(relativePath);                
-                return new VisualTreeDetail(description, container);
+                return new VisualTreeDetail(description, context.GetContext(relativePath));
             }
             else
             {                

--- a/Drums/VDrumExplorer.Data/Json/VisualTreeNodeJson.cs
+++ b/Drums/VDrumExplorer.Data/Json/VisualTreeNodeJson.cs
@@ -32,7 +32,7 @@ namespace VDrumExplorer.Data.Json
             var relativePath = ValidateNotNull(Path, nameof(Path));
             if (repeat == null)
             {
-                var context = parentContext.WithPath(relativePath);
+                var context = parentContext.WithContextFromPath(relativePath);
                 yield return ToVisualTreeNode(context);
             }
             else
@@ -40,7 +40,7 @@ namespace VDrumExplorer.Data.Json
                 var index = ValidateNotNull(Index, nameof(Index));
                 for (int i = 1; i <= repeat; i++)
                 {
-                    var context = parentContext.WithIndex(index, i).WithPath(relativePath);
+                    var context = parentContext.WithIndex(index, i).WithContextFromPath(relativePath);
                     yield return ToVisualTreeNode(context);
                 }
             }

--- a/Drums/VDrumExplorer.Data/Layout/VisualTreeDetail.cs
+++ b/Drums/VDrumExplorer.Data/Layout/VisualTreeDetail.cs
@@ -17,23 +17,12 @@ namespace VDrumExplorer.Data.Layout
         /// Description of this aspect of the details.
         /// </summary>
         public string Description { get; }
-        
-        /// <summary>
-        /// A field chain to a container. May be null, in which case <see cref="DetailDescriptions"/> will not be null.
-        /// If the final field in the chain is null, the final context of the (typically empty) chain is the relevant container.
-        /// </summary>
-        public FieldChain<Container?>? Container { get; }
 
-        public FixedContainer FixContainer(FixedContainer context)
-        {
-            if (Container is null)
-            {
-                throw new InvalidOperationException("No container");
-            }
-            var finalContainer = Container.FinalField;
-            var finalContext = Container.GetFinalContext(context);
-            return finalContainer is null ? finalContext : finalContext.ToChildContext(finalContainer);
-        }
+        /// <summary>
+        /// A container to display as a group of fields.
+        /// May be null, in which case <see cref="DetailDescriptions"/> will not be null.
+        /// </summary>
+        public FixedContainer? Container { get; }
 
         /// <summary>
         /// A list of formattable descriptions. May be null, in which case <see cref="Container"/>
@@ -41,7 +30,7 @@ namespace VDrumExplorer.Data.Layout
         /// </summary>
         public IReadOnlyList<FormattableDescription>? DetailDescriptions { get; }
 
-        public VisualTreeDetail(string description, FieldChain<Container?> container) =>
+        public VisualTreeDetail(string description, FixedContainer container) =>
             (Description, Container, DetailDescriptions) = (description, container, null);
 
         public VisualTreeDetail(string description, IReadOnlyList<FormattableDescription> formatElements) =>

--- a/Drums/VDrumExplorer.Data/Layout/VisualTreeNode.cs
+++ b/Drums/VDrumExplorer.Data/Layout/VisualTreeNode.cs
@@ -55,7 +55,7 @@ namespace VDrumExplorer.Data.Layout
             var container = context.Container;
             Func<VisualTreeNode?, IReadOnlyList<VisualTreeNode>> childrenProvider = newNode =>
                 container.Fields.OfType<Container>().Select(c => FromFixedContainer(newNode, new FixedContainer(c, context.Address + c.Offset))).ToList().AsReadOnly();
-            var details = new List<VisualTreeDetail> { new VisualTreeDetail(container.Description, FieldChain<Container?>.EmptyChain(container)) }.AsReadOnly();
+            var details = new List<VisualTreeDetail> { new VisualTreeDetail(container.Description, context) }.AsReadOnly();
             return new VisualTreeNode(parent, context, childrenProvider, details, new FormattableDescription(container.Description, null), null, null, null);
         }
 

--- a/Drums/VDrumExplorer.Data/ModuleSchema.cs
+++ b/Drums/VDrumExplorer.Data/ModuleSchema.cs
@@ -41,6 +41,12 @@ namespace VDrumExplorer.Data
         /// </summary>
         public VisualTreeNode PhysicalRoot { get; }
 
+        /// <summary>
+        /// A map from a module address to the loadable container at that address.
+        /// (This map doesn't include containers that only contain other containers.)
+        /// </summary>
+        public IReadOnlyDictionary<ModuleAddress, Container> LoadableContainersByAddress { get; }
+
         // Note: this used to be in ModuleJson.ToModuleSchema(), but it turns out it's really useful for
         // a field to have access to the schema it's part of... which is tricky when everything is immutable
         // and the schema also has to have references to the fields. So this code is ugly - and makes field testing
@@ -77,6 +83,11 @@ namespace VDrumExplorer.Data
             KitRoots = LogicalRoot.DescendantNodesAndSelf()
                 .Where(node => node.KitNumber != null)
                 .ToDictionary(node => node.KitNumber!.Value)
+                .AsReadOnly();
+            LoadableContainersByAddress = Root
+                .DescendantsAndSelf()
+                .Where(context => context.Container.Loadable)
+                .ToDictionary(context => context.Address, context => context.Container)
                 .AsReadOnly();
         }
 

--- a/Drums/VDrumExplorer.Data/TD17/KitMfx.json
+++ b/Drums/VDrumExplorer.Data/TD17/KitMfx.json
@@ -54,7 +54,8 @@
       "type": "dynamicOverlay",
       "dynamicOverlay": {
         "size": "0x01_00",
-        "switchOffset": "0x00",
+        "switchContainerOffset": "0x00",
+        "switchField": "Type",
         "containers": [
           "$resource:MultiFx/Delay.json",
           "$resource:MultiFx/TapeEcho.json",

--- a/Drums/VDrumExplorer.Data/TD17/KitUnitVEdit.json
+++ b/Drums/VDrumExplorer.Data/TD17/KitUnitVEdit.json
@@ -8,8 +8,8 @@
       "dynamicOverlay": {
         "size": "0x41",
         "comment": "This is an offset into a different container, to get at the instrument and then its group",
-        "switchOffset": "-0xC000",
-        "switchTransform": "instrumentGroup",
+        "switchContainerOffset": "-0xC000",
+        "switchField": "Instrument",
         "containers": [
           "$resource:VEdit/Off.json",
           "$resource:VEdit/Kick.json",

--- a/Drums/VDrumExplorer.Data/TD50/KitMfx.json
+++ b/Drums/VDrumExplorer.Data/TD50/KitMfx.json
@@ -54,7 +54,8 @@
       "type": "dynamicOverlay",
       "dynamicOverlay": {
         "size": "0x01_00",
-        "switchOffset": "0x00",
+        "switchContainerOffset": "0x00",
+        "switchField": "Type",
         "containers": [
           "$resource:MultiFx/Delay.json",
           "$resource:MultiFx/TapeEcho.json",

--- a/Drums/VDrumExplorer.Data/TD50/KitMidi.json
+++ b/Drums/VDrumExplorer.Data/TD50/KitMidi.json
@@ -446,8 +446,8 @@
       "valueOffset": 1,
       "divisor": 10
     },
-    // FIXME: The spec is contradictory here. The raw values are 0-16 (17 values), but the reported values are 1-15 and GLOBAL (16 values).
-    // Need to investigate... I suspect it means channel 1 to channel 16
+    // The spec is incorrect here. It claims the maximum displayed value is 15, but it's actually 16.
+    // (Then Global comes after 16.)
     {
       "offset": "0x0120",
       "description": "Kick MIDI channel",

--- a/Drums/VDrumExplorer.Data/TD50/KitPadVEdit.json
+++ b/Drums/VDrumExplorer.Data/TD50/KitPadVEdit.json
@@ -8,8 +8,8 @@
       "dynamicOverlay": {
         "size": "0x21",
         "comment": "This is an offset into a different container, to get at the instrument and then its group",
-        "switchOffset": "-0xC000",
-        "switchTransform": "instrumentGroup",
+        "switchContainerOffset": "-0xC000",
+        "switchField": "Instrument",
         "containers": [
           "$resource:VEdit/Off.json",
           "$resource:VEdit/KickA.json",

--- a/Drums/VDrumExplorer.Wpf/DataExplorer.xaml.cs
+++ b/Drums/VDrumExplorer.Wpf/DataExplorer.xaml.cs
@@ -207,7 +207,6 @@ namespace VDrumExplorer.Wpf
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
             // Find the real context based on the container.
-            var container = detail.Container.FinalField;
             context = detail.FixContainer(context);
 
             var fields = context.GetPrimitiveFields(Data)
@@ -506,7 +505,6 @@ namespace VDrumExplorer.Wpf
                 {
                     var detail = (VisualTreeDetail) groupBox.Tag;
 
-                    var container = detail.Container.FinalField;
                     var detailContext = detail.FixContainer(context);
                     Grid grid = (Grid) groupBox.Content;
                     var (overlay, previousContainer) = ((DynamicOverlay, Container)) grid.Tag;
@@ -527,7 +525,7 @@ namespace VDrumExplorer.Wpf
                         {
                             currentContainer.Reset(detailContext, Data);
                         }
-                        groupBox.Content = FormatContainer(context, detail);                        
+                        groupBox.Content = FormatContainer(context, detail);
                     }
                 }
             }

--- a/Drums/VDrumExplorer.Wpf/DataExplorer.xaml.cs
+++ b/Drums/VDrumExplorer.Wpf/DataExplorer.xaml.cs
@@ -192,7 +192,7 @@ namespace VDrumExplorer.Wpf
                 {
                     var container = detail.Container.FinalField;
                     var detailContext = detail.FixContainer(context);
-                    var segmentStart = Data.GetSegment(detailContext.Address + overlay.SwitchOffset).Start;
+                    var segmentStart = Data.GetSegment(detailContext.Address + overlay.SwitchContainerOffset).Start;
                     boundItems.Add((groupBox, segmentStart));
                 }
             }

--- a/Drums/VDrumExplorer.Wpf/ModuleExplorer.cs
+++ b/Drums/VDrumExplorer.Wpf/ModuleExplorer.cs
@@ -89,7 +89,7 @@ namespace VDrumExplorer.Wpf
             IEnumerable<DataSegment> GetSegments(VisualTreeNode treeNode) =>
                 treeNode.Details
                     .Where(d => d.Container is object)
-                    .Select(d => d.FixContainer(treeNode.Context))
+                    .Select(d => d.Container)
                     .Where(fc => fc.Container.Loadable)
                     .Select(fc => Data.GetSegment(fc.Address));
         }


### PR DESCRIPTION
- Fix an issue in the TD-50 schema (documentation was incorrect)
- Clean up how we find the overlay in a dynamic overlay
- Simplify VisualTreeDetail by resolving the container earlier