### PR TITLE
Release 1.0.0-alpha03

### DIFF
--- a/Drums/VDrumExplorer.Wpf/VDrumExplorer.Wpf.csproj
+++ b/Drums/VDrumExplorer.Wpf/VDrumExplorer.Wpf.csproj
@@ -5,8 +5,8 @@
     <TargetFramework>net472</TargetFramework>
     <UseWPF>true</UseWPF>
     <LangVersion>8.0</LangVersion>
-    <Version>1.0.0-alpha02</Version>
-    <AssemblyVersion>1.0.0.2</AssemblyVersion>
+    <Version>1.0.0-alpha03</Version>
+    <AssemblyVersion>1.0.0.3</AssemblyVersion>
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 

--- a/Drums/buildrelease.sh
+++ b/Drums/buildrelease.sh
@@ -32,8 +32,8 @@ zip -rq VDrumExplorer-$version.zip $release_dir
 
 # Setup
 msbuild.exe -property:Configuration=Release -verbosity:quiet ../VDrumExplorer.Setup
-cp ../VDrumExplorer.Setup/bin/Release/en-us/VDrumExplorer-Setup.msi .
+cp ../VDrumExplorer.Setup/bin/Release/en-us/VDrumExplorer-Setup.msi VDrumExplorer-Setup-$version.msi
 # Sign the installer as well
-signtool sign -a -fd SHA256 -f $PFX_PATH -p $PFX_PASSWORD -t http://timestamp.comodoca.com/authenticode VDrumExplorer-Setup.msi
+signtool sign -a -fd SHA256 -f $PFX_PATH -p $PFX_PASSWORD -t http://timestamp.comodoca.com/authenticode VDrumExplorer-Setup-$version.msi
 
 cd ..


### PR DESCRIPTION
- Initial support for TD-27 (some features still TBD, such as default cymbal sizing)
- Change MIDI library choice (hopefully invisible to most users)
- Fix stack overflow error on some changes
- Fix tempo sync switch not reflecting in UI
- Select the first output device as a reasonable default in Instrument Audio Explorer
- Attempt to find a reasonable default input device in instrument recording dialog
